### PR TITLE
feat: Add support for glob patterns in role members

### DIFF
--- a/engine/ladon/rego/core/matcher_glob.rego
+++ b/engine/ladon/rego/core/matcher_glob.rego
@@ -1,0 +1,7 @@
+package ory.core
+
+match_glob(patterns, compare) {
+    pattern := patterns[_]
+    glob.match(pattern, [":"], compare, output)
+    output == true
+}

--- a/engine/ladon/rego/core/role.rego
+++ b/engine/ladon/rego/core/role.rego
@@ -5,3 +5,9 @@ role_ids(roles, subject) = r {
         roles[i].members[_] == subject
     ]
 }
+
+role_ids_glob(roles, subject) = r {
+    r := [role | role := roles[i].id
+        match_glob(roles[i].members, subject)
+    ]
+}

--- a/engine/ladon/rego/glob/main.rego
+++ b/engine/ladon/rego/glob/main.rego
@@ -13,9 +13,9 @@ allow {
 
 decide_allow(policies, roles) {
     effects := [effect | effect := policies[i].effect
-        matcher(policies[i].resources, request.resource)
+        core.match_glob(policies[i].resources, request.resource)
         match_subjects(policies[i].subjects, roles, request.subject)
-        matcher(policies[i].actions, request.action)
+        core.match_glob(policies[i].actions, request.action)
         condition.all_conditions_true(policies[i])
     ]
 
@@ -25,16 +25,10 @@ decide_allow(policies, roles) {
     core.effect_allow(effects)
 }
 
-matcher(patterns, compare) {
-    pattern := patterns[_]
-    glob.match(pattern, [":"], compare, output)
-    output == true
-}
-
 match_subjects(matches, roles, subject) {
-    matcher(matches, subject)
+    core.match_glob(matches, subject)
 } {
-    r := core.role_ids(roles, subject)
+    r := core.role_ids_glob(roles, subject)
     rr := r[_]
-    matcher(matches, rr)
+    core.match_glob(matches, rr)
 }

--- a/engine/ladon/rego/glob/main_test.rego
+++ b/engine/ladon/rego/glob/main_test.rego
@@ -221,3 +221,21 @@ test_allow_combinations_exactly_one_alternative {
     not decide_allow([combination_policy], []) with input as {"resource": "articles:foobar:9", "subject": "subjects:catdog:9", "action": "actions:cat:9"}
     not decide_allow([combination_policy], []) with input as {"resource": "articles:foobar:9", "subject": "subjects:cat:9", "action": "actions:catdog:9"}
 }
+
+# Usage of glob patterns in role members
+policy_with_role = {
+    "id": "4",
+    "resources": [`articles:4`],
+    "subjects": [`role-with-glob`],
+    "actions": [`actions:4`],
+    "effect": "allow",
+}
+
+role_with_glob = {
+    "id": "role-with-glob",
+    "members": [`*@mail.com`]
+}
+
+test_allow_policy {
+    decide_allow([policy_with_role], [role_with_glob]) with input as {"resource": "articles:4", "subject": "subject4@mail.com", "action": "actions:4"}
+}


### PR DESCRIPTION
## Proposed changes

Allow role members to have glob patterns.
Tested with `opa test -v .` in the `engine/ladon/rego/` directory.
